### PR TITLE
Correct login-redirect-to-unauthorized bug

### DIFF
--- a/src/app/Providers/RouteServiceProvider.php
+++ b/src/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/admin/dashboard';
+    public const HOME = '/dashboard';
 
     /**
      * The controller namespace for the application.

--- a/src/resources/js/Pages/Dashboard.vue
+++ b/src/resources/js/Pages/Dashboard.vue
@@ -4,8 +4,13 @@
         <div class="container mx-auto">
             <!-- Page Heading -->
             <header class="bg-white shadow">
-                <div class="py-6 px-4 sm:px-6 lg:px-8">
-                    <h1 class="text-2xl">VaccinateOH Stats</h1>
+                <div class="flex items-center justify-between">
+                    <div class="py-6 px-4 sm:px-6 lg:px-8">
+                        <h1 class="text-2xl">VaccinateOH Stats</h1>
+                    </div>
+                    <div>
+                        <a href="/">Take me to the map!</a>
+                    </div>
                 </div>
             </header>
 


### PR DESCRIPTION
After logging in, the middleware was incorrectly redirecting the user
to a page that was "unauthorized" even though the user was authenticated.

The changes in this PR correct that. The changes modify the behavior
so that a user is redirected to the website's statistics dashboard upon
first being logged in.

There is a small, related change to the dashboard page to add a link to
the map. This change was necessary because there is no other visual obvious
connection between the dashboard page and the map page.