### PR TITLE
Update armorvax API to support easier testing/re-running

### DIFF
--- a/src/app/Http/Controllers/ApiController.php
+++ b/src/app/Http/Controllers/ApiController.php
@@ -6,6 +6,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use App\Helpers\Geo;
 use App\Models\Location;
+use App\Helpers\Address;
+use App\Models\LocationSource;
+use App\Models\LocationType;
+use App\Models\AppointmentType;
+use App\Models\Availability;
 
 use DB;
 
@@ -126,12 +131,127 @@ class ApiController extends Controller
     public function armorvax(Request $request) {
         $data = $request->all();
         $data_string = json_encode($data, JSON_PRETTY_PRINT);
-        $path = sprintf('armorvax/%s/u%d_%s.json', config('app.env'), $request->user()->id, date('Y-m-d_his'));
+        $data_collection = collect(json_decode($data_string));
 
-        // Write the full JSON data to a file on S3
-        \Storage::disk('s3')->write($path, $data_string);
+        $web_appointment_type = AppointmentType::firstOrCreate([
+            'name' => 'Web',
+            'short' => 'web'
+        ]);
+        $armorvax_location_source = LocationSource::firstOrCreate([
+            'name' => 'ArmorVax'
+        ]);
+        // Hardcoded -- boo. This is for Local Health Department.
+        $lhd_location_type_id = 3;
 
-        // echo back the same json that was posted
+        /**
+         * First things first: delete all the existing availabilities
+         * associated with the ArmorVax sites.
+         */
+        Location::bySource('ArmorVax')->each(
+        function ($location, $location_key) {
+            $location->availabilities->each(function ($availability, $key) {
+                // Delete the availabilities associated with each of the
+                // ArmorVax sites already in the database.
+                $availability->delete();
+            });
+        });
+
+        // For each of the entries in the posted JSON array ...
+        $data_collection->each(
+            function ($location_raw, $location_raw_key)
+                use ($armorvax_location_source,
+                     $web_appointment_type,
+                     $lhd_location_type_id) {
+                 // ... For each of the locations in each of the entries ...
+                collect($location_raw->AvailibilitiesByLocation)->each(
+                    function ($availability_raw, $availability_raw_key) 
+                        use ($armorvax_location_source,
+                             $web_appointment_type,
+                             $lhd_location_type_id) {
+                        $name = $availability_raw->LocationName;
+                        $address = Address::standardize(
+                            $availability_raw->LocationAddress->AddressLine1 ."\n".
+                            $availability_raw->LocationAddress->City . ", " .
+                            $availability_raw->LocationAddress->State . " " .
+                            $availability_raw->LocationAddress->Zip);
+                        $address2 = Address::standardize(
+                            $availability_raw->LocationAddress->AddressLine2);
+                        $city = $availability_raw->LocationAddress->City;
+                        $state = $availability_raw->LocationAddress->State;
+                        $zip = $availability_raw->LocationAddress->Zip;
+                        $county = $availability_raw->LocationAddress->County;
+                        $bookinglink = "https://app.armorvax.com";
+                        $location_source_id = $armorvax_location_source->id;
+                        $location_type_id = $lhd_location_type_id;
+
+                        /**
+                         * ... Either find the location that matches or create a
+                         * new one ...
+                         */
+                        $location = Location::firstOrCreate(compact([
+                            'name',
+                            'county',
+                            'zip',
+                            'state',
+                            'address',
+                            'address2',
+                            'bookinglink',
+                            'location_source_id',
+                            'location_type_id',
+                        ]));
+
+                        /**
+                         * If the location has no appointment type
+                         * information associated with it, then
+                         * we will want to associate it with the
+                         * web appointment type.
+                         */
+                        if (!$location->appointmentTypes()->count()) {
+                            $location->appointmentTypes()->attach($web_appointment_type->id);
+                        }
+
+                        /**
+                         * ... For each of the the appointment slots
+                         * available at this location ...
+                         */
+                        collect($availability_raw->AppointmentAvailibility)->each(
+                            function ($appointment_raw, $appointment_raw_key)
+                                use ($location) {
+                                $time = $appointment_raw->Date;
+                                $doses = $appointment_raw->NumberOfAppointments;
+
+                                /**
+                                 * Create an availability.
+                                 */
+                                $availability = Availability::firstOrCreate([
+                                    'location_id' => $location->id,
+                                    'doses' => $doses,
+                                    'availability_time' => $time,
+                                ]);
+                        });
+                    });
+        });
+
+        /**
+         * If the user has a configuration for using s3, then we want to
+         * backup the data that we just received to s3.
+         */
+        try {
+            if (config('filesystems.s3.key')) {
+                $path = sprintf('armorvax/%s/u%d_%s.json', config('app.env'), $request->user()->id, date('Y-m-d_his'));
+                \Storage::disk('s3')->write($path, $data_string);
+            }
+        } catch (Exception $e) {
+            /*
+             * We are going to catch any exceptions that happen so that the
+             * database update does not fail if there is a transient error 
+             * saving to AWS.
+             */
+        }
+
+        /**
+         * Finally, just return back what they sent us.
+         */
         return response()->json($data);
     }
 }

--- a/src/app/Models/Location.php
+++ b/src/app/Models/Location.php
@@ -93,6 +93,20 @@ class Location extends Model
     }
 
     /**
+     * Scope query results by a particular source $source.
+     *
+     * @param QueryBuilder $query
+     * @param string $scope
+     * 
+     * @return QueryBuilder
+     */
+    public function scopeBySource($query, $source) {
+        return $query->whereHas('locationSource', function ($s) use($source) {
+            $s->where('name', '=', $source);
+        });
+    }
+
+    /**
      * Scope query results to order locations by proximity to the provided lat/lng coordinate pair
      *
      * @param QueryBuilder $query


### PR DESCRIPTION
After these changes, the following 2 commands should run a manual import of the latest Armorvax file's availability data:

$data = App\Helpers\Import::getLatestScrapedFile('u25','armorvax/test',true);
App\Helpers\Import::processArmorvax($data);